### PR TITLE
Fixes multiple bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ gradle-app.setting
 
 .idea
 .atom-build.json
+*.iml

--- a/src/main/java/com/github/monster860/fastdmm/FastDMM.java
+++ b/src/main/java/com/github/monster860/fastdmm/FastDMM.java
@@ -78,6 +78,7 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 	private JMenuItem menuItemNew;
 	private JMenuItem menuItemOpen;
 	private JMenuItem menuItemSave;
+	private JMenuItem menuItemExpand;
 	
 	private JPopupMenu currPopup;
 	
@@ -147,7 +148,7 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
             vpData.setLayout(new BorderLayout());
             vpData.setSize(350, 25);
             vpData.setPreferredSize(vpData.getSize());
-            coords = new JLabel(" 0, 0");
+            coords = new JLabel(" No DME loaded.");
             selection = new JLabel(" "); //adding this for when we add selections, so we can show selected tile count
             vpData.add(coords, BorderLayout.WEST);
             vpData.add(selection, BorderLayout.EAST);
@@ -223,10 +224,11 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
             menuItem.addActionListener(FastDMM.this);
             menu.add(menuItem);
             
-            menuItem = new JMenuItem("Expand Map");
-            menuItem.setActionCommand("expand");
-            menuItem.addActionListener(FastDMM.this);
-            menu.add(menuItem);
+            menuItemExpand = new JMenuItem("Expand Map");
+            menuItemExpand.setActionCommand("expand");
+            menuItemExpand.addActionListener(FastDMM.this);
+			menuItemExpand.setEnabled(false);
+            menu.add(menuItemExpand);
             
             menu.addSeparator();
             
@@ -297,14 +299,15 @@ return false;
 			int returnVal = fc.showOpenDialog(this);
 			if(returnVal == JFileChooser.APPROVE_OPTION) {
 				synchronized(this) {
-					dme = fc.getSelectedFile();
 					objTree = null;
 					dmm = null;
+					dme = fc.getSelectedFile();
 				}
 				areMenusFrozen = true;
 				menuItemOpen.setEnabled(false);
 				menuItemSave.setEnabled(false);
 				menuItemNew.setEnabled(false);
+				menuItemExpand.setEnabled(false);
 				new Thread() {
 					public void run() {
 						try {
@@ -348,12 +351,14 @@ return false;
 				try {
 					newDmm = new DMM(dmmList.getSelectedValue(), objTree, this);
 					dmm = newDmm;
+					menuItemExpand.setEnabled(true);
 				} catch (Exception ex) {
 					StringWriter sw = new StringWriter();
 					PrintWriter pw = new PrintWriter(sw);
 					ex.printStackTrace(pw);
 					JOptionPane.showMessageDialog(FastDMM.this, sw.getBuffer(), "Error", JOptionPane.ERROR_MESSAGE);
 					dmm = null;
+					menuItemExpand.setEnabled(false);
 				} finally {
 					areMenusFrozen = false;
 				}
@@ -393,6 +398,7 @@ return false;
 				try {
 					dmm = new DMM(new File(dme.getParentFile(), usePath), objTree, this);
 					dmm.setSize(1, 1, 1, maxX, maxY, maxZ);
+					menuItemExpand.setEnabled(true);
 				} catch (IOException ex) {
 					ex.printStackTrace();
 				}
@@ -548,7 +554,7 @@ return false;
 		
 		if(dme != null) {
 			if(dmm != null) {
-				if(selX >= 1 && selY >= 1) {
+				if(selX >= 1 && selY >= 1 && selX <= dmm.maxX && selY <= dmm.maxY) {
 					String tcoord = " " + String.valueOf(selX) + ", " + String.valueOf(selY);
 					coords.setText(tcoord);
 				} else {

--- a/src/main/java/com/github/monster860/fastdmm/FastDMM.java
+++ b/src/main/java/com/github/monster860/fastdmm/FastDMM.java
@@ -227,7 +227,7 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
             menuItemExpand = new JMenuItem("Expand Map");
             menuItemExpand.setActionCommand("expand");
             menuItemExpand.addActionListener(FastDMM.this);
-			menuItemExpand.setEnabled(false);
+            menuItemExpand.setEnabled(false);
             menu.add(menuItemExpand);
             
             menu.addSeparator();


### PR DESCRIPTION
Fixes #23. This was caused by the fact that dmms were set to null only after the dme has been unloaded.
Fixes #25.
Also fixes a bug that went unnoticed in my testing of #24, that meant that the app would display coordinates that exceeded the maps' maxX and maxY.

Also adds a .gitignore entry for .iml files created by IntelliJ IDEA.
