### PR TITLE
Added rudimentary undo/redo functionality

### DIFF
--- a/src/main/java/com/github/monster860/fastdmm/FastDMM.java
+++ b/src/main/java/com/github/monster860/fastdmm/FastDMM.java
@@ -56,6 +56,9 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 	public DMM dmm;
 	public List<DMM> loadedMaps = new ArrayList<DMM>();
 	public Map<String, ModifiedType> modifiedTypes = new HashMap<>();
+	
+	private Stack<Undoable> undostack = new Stack<Undoable>();
+	private Stack<Undoable> redostack = new Stack<Undoable>();
 
 	public float viewportX = 0;
 	public float viewportY = 0;
@@ -87,6 +90,8 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 	private JMenuItem menuItemSave;
 	private JMenuItem menuItemExpand;
 	private JMenuItem menuItemMapImage;
+	private JMenuItem menuItemUndo;
+	private JMenuItem menuItemRedo;
 
 	private JPopupMenu currPopup;
 
@@ -279,7 +284,22 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 			menu.add(menuItemMapImage);
 
 			initRecent("dme");
+			
+			menu = new JMenu("Edit");
+			menuBar.add(menu);
 
+			menuItemUndo = new JMenuItem("Undo", KeyEvent.VK_U);
+			menuItemUndo.setActionCommand("undo");
+			menuItemUndo.addActionListener(FastDMM.this);
+			menuItemUndo.setEnabled(false);
+			menu.add(menuItemUndo);
+
+			menuItemRedo = new JMenuItem("Redo", KeyEvent.VK_R);
+			menuItemRedo.setActionCommand("redo");
+			menuItemRedo.addActionListener(FastDMM.this);
+			menuItemRedo.setEnabled(false);
+			menu.add(menuItemRedo);
+			
 			menu = new JMenu("Options");
 			menu.setMnemonic(KeyEvent.VK_O);
 			menuBar.add(menu);
@@ -496,6 +516,10 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 					e1.printStackTrace();
 				}
 			}
+		} else if("undo".equals(e.getActionCommand())) {
+			undoAction();
+		} else if("redo".equals(e.getActionCommand())) {
+			redoAction();
 		}
 	}
 
@@ -1313,4 +1337,37 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 		}
 		return valid;
 	}
+	
+	public void addToUndoStack(Undoable action){
+		if(action == null) {
+			return;
+		}
+		undostack.push(action);
+		redostack.clear();
+		menuItemUndo.setEnabled(true);
+		menuItemRedo.setEnabled(false);
+	}
+	
+	public boolean undoAction(){
+		if(undostack.empty()) {
+			return false;
+		}
+		Undoable action = undostack.pop();
+		redostack.push(action);
+		menuItemRedo.setEnabled(true);
+		menuItemUndo.setEnabled(!undostack.isEmpty());
+		return action.undo();
+	}
+	
+	public boolean redoAction(){
+		if(redostack.empty()) {
+			return false;
+		}
+		Undoable action = redostack.pop();
+		undostack.push(action);
+		menuItemUndo.setEnabled(true);
+		menuItemRedo.setEnabled(!redostack.isEmpty());
+		return action.redo();
+	}
+	
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/DeleteListener.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/DeleteListener.java
@@ -1,40 +1,27 @@
 package com.github.monster860.fastdmm.editing;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import com.github.monster860.fastdmm.FastDMM;
 import com.github.monster860.fastdmm.dmmmap.Location;
 import com.github.monster860.fastdmm.dmmmap.TileInstance;
 import com.github.monster860.fastdmm.objtree.ObjInstance;
 
-public class DeleteListener implements ActionListener {
-	
-	FastDMM editor;
-	Location location;
-	ObjInstance oInstance;
+public class DeleteListener extends SimpleContextMenuListener {
 	
 	public DeleteListener(FastDMM editor, Location mapLocation, ObjInstance instance) {
-		this.editor = editor;
-		this.location = mapLocation;
-		this.oInstance = instance;
+		super(editor, mapLocation, instance);
 	}
 	
 	@Override
-	public void actionPerformed(ActionEvent e) {
-		if(editor.dmm == null)
-			return;
+	public String doAction(String oldkey) {
 		synchronized(editor) {
-			String key = editor.dmm.map.get(location);
-			if(key == null)
-				return;
-			TileInstance ti = editor.dmm.instances.get(key);
+			TileInstance ti = editor.dmm.instances.get(oldkey);
 			if(ti == null)
-				return;
+				return null;
 			
 			String newKey = ti.removeObject(oInstance);
 			
 			editor.dmm.putMap(location, newKey);
+			return newKey;
 		}
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/EditVarsListener.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/EditVarsListener.java
@@ -1,43 +1,33 @@
 package com.github.monster860.fastdmm.editing;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import com.github.monster860.fastdmm.FastDMM;
 import com.github.monster860.fastdmm.dmmmap.Location;
 import com.github.monster860.fastdmm.dmmmap.TileInstance;
 import com.github.monster860.fastdmm.objtree.ModifiedType;
 import com.github.monster860.fastdmm.objtree.ObjInstance;
 
-public class EditVarsListener implements ActionListener {
-	
-	FastDMM editor;
-	Location location;
-	ObjInstance oInstance;
+public class EditVarsListener extends SimpleContextMenuListener {
 	
 	public EditVarsListener(FastDMM editor, Location mapLocation, ObjInstance instance) {
-		this.editor = editor;
-		this.location = mapLocation;
-		this.oInstance = instance;
+		super(editor, mapLocation, instance);
 	}
-	
+
 	@Override
-	public void actionPerformed(ActionEvent e) {
-		if(editor.dmm == null)
-			return;
+	public String doAction(String oldkey) {
 		TileInstance ti;
 		synchronized(editor) {
 			String key = editor.dmm.map.get(location);
 			if(key == null)
-				return;
+				return null;
 			ti = editor.dmm.instances.get(key);
 			if(ti == null)
-				return;
+				return null;
 		}
 		ModifiedType mt = ModifiedType.deriveFrom(oInstance);
 		if(!mt.viewVariables(editor))
-			return;
-		synchronized(editor) {	
+			return null;
+
+		synchronized(editor) {
 			if(editor.modifiedTypes.containsKey(mt.toString())) {
 				mt = editor.modifiedTypes.get(mt.toString());
 			} else {
@@ -46,10 +36,10 @@ public class EditVarsListener implements ActionListener {
 					mt.parent.addInstance(mt);
 				}
 			}
-			
-			String newKey = ti.replaceObject(oInstance, mt.vars.size() != 0 ? mt : mt.parent);
-			
-			editor.dmm.putMap(location, newKey);
 		}
+		String newKey = ti.replaceObject(oInstance, mt.vars.size() != 0 ? mt : mt.parent);
+		
+		editor.dmm.putMap(location, newKey);
+		return newKey;
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/FloatingSelection.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/FloatingSelection.java
@@ -26,6 +26,7 @@ import com.github.monster860.fastdmm.dmirender.RenderInstance;
 import com.github.monster860.fastdmm.dmmmap.DMM;
 import com.github.monster860.fastdmm.dmmmap.Location;
 import com.github.monster860.fastdmm.dmmmap.TileInstance;
+import com.github.monster860.fastdmm.editing.placement.UndoablePlacement;
 import com.github.monster860.fastdmm.objtree.ObjInstance;
 import com.github.monster860.fastdmm.objtree.ObjectTree;
 
@@ -123,6 +124,7 @@ public class FloatingSelection {
 	}
 	
 	public void anchor(DMM map) {
+		HashMap<Location, String[]> changes = new HashMap<Location, String[]>();
 		for(Entry<Location,TileInstance> entry : objects.entrySet()) {
 			Location relL = entry.getKey();
 			Location l = new Location(x+relL.x,y+relL.y,z);
@@ -151,9 +153,13 @@ public class FloatingSelection {
 			ti.objs.addAll(addTi.objs);
 			ti.sortObjs();			
 			String newKey = map.getKeyForInstance(ti);
-			if(newKey != null)
+			String[] keys = {key, newKey};
+			if(newKey != null) {
 				map.putMap(l, newKey);
+				changes.put(l,  keys);
+			}
 		}
+		map.editor.addToUndoStack(new UndoablePlacement.Move(map.editor, changes));
 	}
 	
 	public void toClipboard() {

--- a/src/main/java/com/github/monster860/fastdmm/editing/MoveToBottomListener.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/MoveToBottomListener.java
@@ -1,39 +1,26 @@
 package com.github.monster860.fastdmm.editing;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import com.github.monster860.fastdmm.FastDMM;
 import com.github.monster860.fastdmm.dmmmap.Location;
 import com.github.monster860.fastdmm.dmmmap.TileInstance;
 import com.github.monster860.fastdmm.objtree.ObjInstance;
 
-public class MoveToBottomListener implements ActionListener {
-	FastDMM editor;
-	Location location;
-	ObjInstance oInstance;
+public class MoveToBottomListener extends SimpleContextMenuListener {
 	
 	public MoveToBottomListener(FastDMM editor, Location mapLocation, ObjInstance instance) {
-		this.editor = editor;
-		this.location = mapLocation;
-		this.oInstance = instance;
+		super(editor, mapLocation, instance);
 	}
-	
+
 	@Override
-	public void actionPerformed(ActionEvent e) {
-		if(editor.dmm == null)
-			return;
+	public String doAction(String oldkey) {
 		synchronized(editor) {
-			String key = editor.dmm.map.get(location);
-			if(key == null)
-				return;
-			TileInstance ti = editor.dmm.instances.get(key);
+			TileInstance ti = editor.dmm.instances.get(oldkey);
 			if(ti == null)
-				return;
+				return null;
 			
 			String newKey = ti.moveObjToBottom(oInstance);
-			
 			editor.dmm.putMap(location, newKey);
+			return newKey;
 		}
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/MoveToTopListener.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/MoveToTopListener.java
@@ -1,39 +1,26 @@
 package com.github.monster860.fastdmm.editing;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import com.github.monster860.fastdmm.FastDMM;
 import com.github.monster860.fastdmm.dmmmap.Location;
 import com.github.monster860.fastdmm.dmmmap.TileInstance;
 import com.github.monster860.fastdmm.objtree.ObjInstance;
 
-public class MoveToTopListener implements ActionListener {
-	FastDMM editor;
-	Location location;
-	ObjInstance oInstance;
+public class MoveToTopListener extends SimpleContextMenuListener {
 	
 	public MoveToTopListener(FastDMM editor, Location mapLocation, ObjInstance instance) {
-		this.editor = editor;
-		this.location = mapLocation;
-		this.oInstance = instance;
+		super(editor, mapLocation, instance);
 	}
 	
 	@Override
-	public void actionPerformed(ActionEvent e) {
-		if(editor.dmm == null)
-			return;
+	public String doAction(String oldkey) {
 		synchronized(editor) {
-			String key = editor.dmm.map.get(location);
-			if(key == null)
-				return;
-			TileInstance ti = editor.dmm.instances.get(key);
+			TileInstance ti = editor.dmm.instances.get(oldkey);
 			if(ti == null)
-				return;
+				return null;
 			
 			String newKey = ti.moveObjToTop(oInstance);
-			
 			editor.dmm.putMap(location, newKey);
+			return newKey;
 		}
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/SimpleContextMenuListener.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/SimpleContextMenuListener.java
@@ -1,0 +1,41 @@
+package com.github.monster860.fastdmm.editing;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import com.github.monster860.fastdmm.FastDMM;
+import com.github.monster860.fastdmm.dmmmap.Location;
+import com.github.monster860.fastdmm.editing.placement.UndoablePlacement;
+import com.github.monster860.fastdmm.objtree.ObjInstance;
+
+public abstract class SimpleContextMenuListener implements ActionListener {
+	
+	FastDMM editor;
+	Location location;
+	ObjInstance oInstance;
+	
+	private String oldkey;
+	private String newkey;
+	
+	public SimpleContextMenuListener(FastDMM editor, Location mapLocation, ObjInstance instance) {
+		this.editor = editor;
+		this.location = mapLocation;
+		this.oInstance = instance;
+	}
+	
+	public abstract String doAction(String oldKey);
+	
+	public void actionPerformed(ActionEvent e) {
+		if(editor.dmm == null)
+			return;
+		oldkey = editor.dmm.map.get(location);
+		if(oldkey == null){
+			return;
+		}
+		newkey = doAction(oldkey);
+		if(newkey != null && !newkey.equals(oldkey)) {
+			editor.addToUndoStack(new UndoablePlacement.Replace(editor, oldkey, newkey, location));
+		}
+	}
+	
+}

--- a/src/main/java/com/github/monster860/fastdmm/editing/Undoable.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/Undoable.java
@@ -1,0 +1,6 @@
+package com.github.monster860.fastdmm.editing;
+
+public interface Undoable {
+	public boolean undo();
+	public boolean redo();
+}

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/BlockPlacementHandler.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/BlockPlacementHandler.java
@@ -71,6 +71,7 @@ public class BlockPlacementHandler implements PlacementHandler {
 	public void finalizePlacement() {
 		Location l1 = new Location(Math.min(startLocation.x, endLocation.x),Math.min(startLocation.y, endLocation.y),Math.min(startLocation.z, endLocation.z));
 		Location l2 = new Location(Math.max(startLocation.x, endLocation.x),Math.max(startLocation.y, endLocation.y),Math.max(startLocation.z, endLocation.z));
+		HashSet<Location> locations = new HashSet<Location>();
 		for(int x = l1.x; x <= l2.x; x++)
 			for(int y = l1.y; y <= l2.y; y++) {
 				Location l = new Location(x, y, l1.z);
@@ -80,7 +81,9 @@ public class BlockPlacementHandler implements PlacementHandler {
 					TileInstance tInstance = editor.dmm.instances.get(key);
 					String newKey = tInstance.addObject(oInstance);
 					editor.dmm.putMap(l, newKey);
+					locations.add(l);
 				}
 			}
+		editor.addToUndoStack(new UndoablePlacement.Add(editor, oInstance, locations));
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/DefaultPlacementHandler.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/DefaultPlacementHandler.java
@@ -64,13 +64,16 @@ public class DefaultPlacementHandler implements PlacementHandler {
 
 	@Override
 	public void finalizePlacement() {
+		HashSet<Location> locations = new HashSet<Location>();
 		for(Location l : usedLocations) {
 			String key = editor.dmm.map.get(l);
 			if(key != null) {
 				TileInstance tInstance = editor.dmm.instances.get(key);
 				String newKey = tInstance.addObject(oInstance);
 				editor.dmm.putMap(l, newKey);
+				locations.add(l);
 			}
 		}
+		editor.addToUndoStack(new UndoablePlacement.Add(editor, oInstance, locations));
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/DeleteBlockPlacementHandler.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/DeleteBlockPlacementHandler.java
@@ -43,6 +43,7 @@ public class DeleteBlockPlacementHandler implements PlacementHandler {
 	public void finalizePlacement() {
 		Location l1 = new Location(Math.min(startLocation.x, endLocation.x),Math.min(startLocation.y, endLocation.y),Math.min(startLocation.z, endLocation.z));
 		Location l2 = new Location(Math.max(startLocation.x, endLocation.x),Math.max(startLocation.y, endLocation.y),Math.max(startLocation.z, endLocation.z));
+		HashSet<Location> locations = new HashSet<Location>();
 		for(int x = l1.x; x <= l2.x; x++)
 			for(int y = l1.y; y <= l2.y; y++) {
 				Location l = new Location(x, y, l1.z);
@@ -52,7 +53,9 @@ public class DeleteBlockPlacementHandler implements PlacementHandler {
 					TileInstance tInstance = editor.dmm.instances.get(key);
 					String newKey = tInstance.removeObjectOrSubtypes(oInstance);
 					editor.dmm.putMap(l, newKey);
+					locations.add(l);
 				}
 			}
+		editor.addToUndoStack(new UndoablePlacement.Delete(editor, oInstance, locations));
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/DeletePlacementHandler.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/DeletePlacementHandler.java
@@ -30,14 +30,19 @@ public class DeletePlacementHandler implements PlacementHandler {
 
 	@Override
 	public void finalizePlacement() {
+		HashSet<Location> locations = new HashSet<Location>();
 		for(Location l : usedLocations) {
 			String key = editor.dmm.map.get(l);
 			if(key != null) {
 				TileInstance tInstance = editor.dmm.instances.get(key);
 				String newKey = tInstance.removeObjectOrSubtypes(oInstance);
-				editor.dmm.putMap(l, newKey);
+				if(!key.equals(newKey)){
+					editor.dmm.putMap(l, newKey);
+					locations.add(l);
+				}
 			}
 		}
+		editor.addToUndoStack(new UndoablePlacement.Delete(editor, oInstance, locations));
 	}
 
 	@Override

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/DirectionalPlacementHandler.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/DirectionalPlacementHandler.java
@@ -136,6 +136,7 @@ public class DirectionalPlacementHandler implements PlacementHandler {
 			TileInstance tInstance = editor.dmm.instances.get(key);
 			String newKey = tInstance.addObject(usedInstance);
 			editor.dmm.putMap(usedLocation, newKey);
+			editor.addToUndoStack(new UndoablePlacement.Replace(editor, key, newKey, usedLocation));
 		}
 	}
 }

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/SelectPlacementMode.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/SelectPlacementMode.java
@@ -3,6 +3,7 @@ package com.github.monster860.fastdmm.editing.placement;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ public class SelectPlacementMode implements PlacementMode {
         if(selection.contains(initialLocation) && !editor.isAltPressed && !editor.isCtrlPressed && !editor.isShiftPressed) {
         	floatSelect = new FloatingSelection(editor.dmm, selection, editor);
 			synchronized(editor) {
+				HashMap<Location, String[]> changes = new HashMap<Location, String[]>();
 				for(Location l : selection) {
 					String key = editor.dmm.map.get(l);
 					if(key == null)
@@ -38,9 +40,13 @@ public class SelectPlacementMode implements PlacementMode {
 						continue;
 				
 					String newKey = ti.deleteAllInFilter(editor);
-				
+					
+					String[] keys = {key, newKey};
+					changes.put(l, keys);
+					
 					editor.dmm.putMap(l, newKey);
 				}
+				editor.addToUndoStack(new UndoablePlacement.Move(editor, changes));
 			}
 			clearSelection();
         }
@@ -163,9 +169,10 @@ public class SelectPlacementMode implements PlacementMode {
 				if(editor.dmm == null)
 					return;
 				if(doCopy) {
-					new FloatingSelection(editor.dmm, selection.selection, editor).toClipboard();;
+					new FloatingSelection(editor.dmm, selection.selection, editor).toClipboard();
 				}
 				if(doDelete) {
+					HashMap<Location, String[]> changes = new HashMap<Location, String[]>();
 					for(Location l : selection.selection) {
 						String key = editor.dmm.map.get(l);
 						if(key == null)
@@ -175,9 +182,13 @@ public class SelectPlacementMode implements PlacementMode {
 							continue;
 					
 						String newKey = ti.deleteAllInFilter(editor);
-					
+						
+						String[] keys = {key, newKey};
+						changes.put(l, keys);
+						
 						editor.dmm.putMap(l, newKey);
 					}
+					editor.addToUndoStack(new UndoablePlacement.Move(editor, changes));
 					selection.clearSelection();
 				}
 			}

--- a/src/main/java/com/github/monster860/fastdmm/editing/placement/UndoablePlacement.java
+++ b/src/main/java/com/github/monster860/fastdmm/editing/placement/UndoablePlacement.java
@@ -1,0 +1,165 @@
+package com.github.monster860.fastdmm.editing.placement;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.monster860.fastdmm.FastDMM;
+import com.github.monster860.fastdmm.dmmmap.Location;
+import com.github.monster860.fastdmm.dmmmap.TileInstance;
+import com.github.monster860.fastdmm.editing.Undoable;
+import com.github.monster860.fastdmm.objtree.ObjInstance;
+
+public abstract class UndoablePlacement implements Undoable{
+	protected FastDMM editor;
+	protected Set<Location> locations;
+	
+	public UndoablePlacement(FastDMM editor, Set<Location> locations){
+		this.editor = editor;
+		this.locations = locations;
+	}
+	
+	public UndoablePlacement(FastDMM editor, Location location){
+		this.editor = editor;
+		this.locations = new HashSet<Location>();
+		locations.add(location);
+	}
+
+	@Override
+	public boolean undo() {
+		if(editor.dmm == null)
+			return false;
+		for(Location l : locations) {
+			if(editor.dmm.map.get(l) != null){
+				undoLoc(l);
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean redo() {
+		if(editor.dmm == null)
+			return false;
+		for(Location l : locations) {
+			if(editor.dmm.map.get(l) != null){
+				redoLoc(l);
+			}
+		}
+		return true;
+	}
+	
+	public abstract void undoLoc(Location l);
+	public abstract void redoLoc(Location l);
+	
+	public static class Add extends UndoablePlacement{
+		private ObjInstance instance;
+
+		public Add(FastDMM editor, ObjInstance instance, Set<Location> locations) {
+			super(editor, locations);
+			this.instance = instance;
+		}
+		
+		public Add(FastDMM editor, ObjInstance instance, Location location) {
+			super(editor, location);
+			this.instance = instance;
+		}
+
+		@Override
+		public void undoLoc(Location l) {
+			String key = editor.dmm.map.get(l);
+			TileInstance tInstance = editor.dmm.instances.get(key);
+			String newKey = tInstance.removeObjectOrSubtypes(instance);
+			editor.dmm.putMap(l, newKey);
+		}
+
+		@Override
+		public void redoLoc(Location l) {
+			String key = editor.dmm.map.get(l);
+			TileInstance tInstance = editor.dmm.instances.get(key);
+			String newKey = tInstance.addObject(instance);
+			editor.dmm.putMap(l, newKey);
+		}
+		
+	}
+	
+	public static class Delete extends UndoablePlacement{
+		private ObjInstance instance;
+
+		public Delete(FastDMM editor, ObjInstance instance, Set<Location> locations) {
+			super(editor, locations);
+			this.instance = instance;
+		}
+
+		public Delete(FastDMM editor, ObjInstance instance, Location location) {
+			super(editor, location);
+			this.instance = instance;
+		}
+
+		@Override
+		public void undoLoc(Location l) {
+			String key = editor.dmm.map.get(l);
+			TileInstance tInstance = editor.dmm.instances.get(key);
+			String newKey = tInstance.addObject(instance);
+			editor.dmm.putMap(l, newKey);
+		}
+
+		@Override
+		public void redoLoc(Location l) {
+			String key = editor.dmm.map.get(l);
+			TileInstance tInstance = editor.dmm.instances.get(key);
+			String newKey = tInstance.removeObjectOrSubtypes(instance);
+			editor.dmm.putMap(l, newKey);
+		}
+	}
+	
+	public static class Replace extends UndoablePlacement{
+		private String preKey;
+		private String postKey;
+
+		public Replace(FastDMM editor, String preKey, String postKey, Set<Location> locations) {
+			super(editor, locations);
+			this.preKey = preKey;
+			this.postKey = postKey;
+		}
+		
+		public Replace(FastDMM editor, String preKey, String postKey, Location location) {
+			super(editor, location);
+			this.preKey = preKey;
+			this.postKey = postKey;
+		}
+
+		@Override
+		public void undoLoc(Location l) {
+			editor.dmm.putMap(l, preKey);
+		}
+
+		@Override
+		public void redoLoc(Location l) {
+			editor.dmm.putMap(l, postKey);
+		}
+	}
+	
+	public static class Move extends UndoablePlacement{
+		private Map<Location, String[]> loc_keys;
+		
+		//The zeroth entry in the String[] is the key before the change, the first entry is the key after the change
+		public Move(FastDMM editor, Map<Location, String[]> locations) {
+			super(editor, locations.keySet());
+			loc_keys = locations;
+		}
+		
+		@Override
+		public void undoLoc(Location l) {
+			String newKey = loc_keys.get(l)[0];
+			editor.dmm.putMap(l, newKey);
+		}
+		
+		@Override
+		public void redoLoc(Location l) {
+			String newKey = loc_keys.get(l)[1];
+			editor.dmm.putMap(l, newKey);
+		}
+	}
+	
+}


### PR DESCRIPTION
Closes #38 

Added undo and redo for the following operations:
* Placing an atom/atoms
* Deleting an atom/atoms
* Editing the variables of an atom
* Moving an atom to the top/bottom of the tile
* Moving a selection
* Deleting a selection
* Pasting a selection

At the moment, moving a selection is considered two operations: pasting the selection to the new place, and removing it from the old place.

The only way to use undo and redo is to use the dropdown menu. No hotkeys yet.